### PR TITLE
Fix cross-platform behaviour when calling ImageMagick

### DIFF
--- a/Copy-Mediafiles.ps1
+++ b/Copy-Mediafiles.ps1
@@ -221,10 +221,10 @@ function Invoke-ImageMagick([string[]]$arguments) {
 
 function Test-ImageMagick() {
 	if (Test-ImageMagickCommand "magick") {
-		$useMagickCommand = $true
+		return $true
 	}
 	elseif (Test-ImageMagickCommand "identify") {
-		$useMagickCommand = $false
+		return $false
 	}
 	else {
 		Write-Error "ImageMagick not detected"
@@ -245,5 +245,5 @@ function Test-ImageMagickCommand([string]$command) {
 	}
 }
 
-Test-ImageMagick
+$useMagickCommand = Test-ImageMagick
 Convert-Folder $inputPath $outputPath

--- a/Copy-Mediafiles.ps1
+++ b/Copy-Mediafiles.ps1
@@ -220,19 +220,28 @@ function Invoke-ImageMagick([string[]]$arguments) {
 }
 
 function Test-ImageMagick() {
-	$out = magick -version | Join-String
-	if ($out.Contains("ImageMagick")) {
+	if (Test-ImageMagickCommand "magick") {
 		$useMagickCommand = $true
 	}
+	elseif (Test-ImageMagickCommand "identify") {
+		$useMagickCommand = $false
+	}
 	else {
-		$out = identify -version | Join-String
+		Write-Error "ImageMagick not detected"
+		exit 1
+	}
+}
+
+function Test-ImageMagickCommand([string]$command) {
+	try {
+		$out = & $command '-version' | Join-String
 		if ($out.Contains("ImageMagick")) {
-			$useMagickCommand = $false
+			return $true
 		}
-		else {
-			Write-Error "ImageMagick not detected"
-			exit 1
-		}
+		return $false
+	}
+	catch {
+		return $false
 	}
 }
 

--- a/Copy-Mediafiles.ps1
+++ b/Copy-Mediafiles.ps1
@@ -212,10 +212,10 @@ function Convert-PathForKid3([string]$path) {
 
 function Invoke-ImageMagick([string[]]$arguments) {
 	if ($useMagickCommand) {
-		& 'magick' $arguments
+		return & 'magick' $arguments
 	}
 	else {
-		& $arguments
+		return & $arguments[0] $arguments[1..10]
 	}
 }
 

--- a/Copy-Mediafiles.ps1
+++ b/Copy-Mediafiles.ps1
@@ -178,14 +178,14 @@ function Import-CoverImage([string]$audioFilePath, [string]$coverImgPath) {
 }
 
 function Convert-CoverImage([string]$coverFileName) {
-	[int]$width = magick identify -format "%w" $coverFileName
-	$format = magick identify -format "%m" $coverFileName
+	[int]$width = Invoke-ImageMagick @("identify", "-format", "%w", $coverFileName)
+	$format = Invoke-ImageMagick @("identify", "-format", "%m", $coverFileName)
 	Write-Host "Cover is" $format "$($width)px"
 
 	if ((-not $supportedImageFormats.Contains($format)) -or $width -gt $maxImageSize) {
 		$convertedImgPath = Get-TempFilePath $targetImageFormat
 		$targetImageSize = [System.Math]::Min($width, $idealImageSize)
-		magick convert $coverFileName -resize "$($targetImageSize)x" -strip $convertedImgPath
+		Invoke-ImageMagick @("convert", $coverFileName, "-resize", "$($targetImageSize)x", "-strip", $convertedImgPath)
 
 		Write-Host "Cover converted to JPEG $($targetImageSize)px"
 		return $convertedImgPath
@@ -210,4 +210,31 @@ function Convert-PathForKid3([string]$path) {
 	return $path.Replace("\", "\\").Replace("'", "\'")
 }
 
+function Invoke-ImageMagick([string[]]$arguments) {
+	if ($useMagickCommand) {
+		& 'magick' $arguments
+	}
+	else {
+		& $arguments
+	}
+}
+
+function Test-ImageMagick() {
+	$out = magick -version | Join-String
+	if ($out.Contains("ImageMagick")) {
+		$useMagickCommand = $true
+	}
+	else {
+		$out = identify -version | Join-String
+		if ($out.Contains("ImageMagick")) {
+			$useMagickCommand = $false
+		}
+		else {
+			Write-Error "ImageMagick not detected"
+			exit 1
+		}
+	}
+}
+
+Test-ImageMagick
 Convert-Folder $inputPath $outputPath

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ is embedded as cover art in the files in the destination folder.
 
 ## Implementation
 
-Implemented as a cross-platform PowerShell script. Tested mainly on Ubuntu Linux.
+Implemented as a cross-platform PowerShell script. Tested mainly on Windows and Ubuntu Linux.
 
 ### External tools
 * PowerShell 7, to run the script
@@ -43,7 +43,7 @@ Implemented as a cross-platform PowerShell script. Tested mainly on Ubuntu Linux
 * Kid3 CLI, to read and write embedded cover art
 * ImageMagick, to parse and convert the cover art
 
-These tools are all available on Windows and macOS, so in theory the script should work on those platforms.
+These tools are all available on Windows, Linux, and macOS, so in theory the script should work on those platforms.
 
 To install all prerequisites on Ubuntu, run:
 ```


### PR DESCRIPTION
On Windows we need to call e.g. "magick convert ..." but on Linux we just call "convert ...". Updated script to detect and handle these scenarios.